### PR TITLE
Update the spec from the implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,10 @@ See the section: [How does it work? - Protocol Description](#how-does-it-work-pr
 To decode a CID, follow the following algorithm:
 
 1. If it's a string (ASCII/UTF-8):
-  * If it is 46 characters long and starts with `Qm...`, it's a CIDv0. Decode it as base58btc and:
-    * The CID's multihash is the decoded CID.
-    * The CID's multicodec is DagProtobuf.
-    * The CID's version is 0.
-  * Otherwise, decode it according to the multibase spec.
+  * If it is 46 characters long and starts with `Qm...`, it's a CIDv0. Decode it as base58btc and continue to step 2.
+  * Otherwise, decode it according to the multibase spec and:
+    * If the first decoded byte is 0x12, return an error. CIDv0 CIDs may not be multibase encoded and there will be no CIDv18 (0x12 = 18) to prevent ambiguity with decoded CIDv0s.
+    * Otherwise, you now have a binary CID. Continue to step 2.
 2. Given a (binary) CID (`cid`):
    * If it's 34 bytes long with the leading bytes `[0x12, 0x20, ...]`, it's a CIDv0.
      * The CID's multihash is `cid`.
@@ -120,7 +119,7 @@ To decode a CID, follow the following algorithm:
      * The CID's version is 0.
    * Otherwise, let `N` be the first varint in `cid`. This is the CID's version.
      * If `N == 1` (CIDv1):
-       * THe CID's multicodec is the second varint in `cid`
+       * The CID's multicodec is the second varint in `cid`
        * The CID's multihash is the rest of the `cid` (after the second varint).
        * The CID's version is 1.
      * If `N <= 0`, the CID is malformed.


### PR DESCRIPTION
1. CIDv0 only supports SHA256 multihashes.
~~2. In CIDv0, the multibase *can* be specified but defaults to base58btc.~~

This commit also describes the proper algorithm for decoding CIDs as it's non-obvious.

Fixes #11