### PR TITLE
Added Elixir version of CID

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ To decode a CID, follow the following algorithm:
 - [js-cid](https://github.com/ipld/js-cid)
 - [rust-cid](https://github.com/ipld/rust-cid)
 - [py-cid](https://github.com/ipld/py-cid)
+- [elixir-cid](https://github.com/nocursor/ex-cid)
 - [Add yours today!](https://github.com/ipld/cid/edit/master/README.md)
 
 ## FAQ


### PR DESCRIPTION
Initial pass at CID port to Elixir. 

See README for usage + details, but a quick overview:

* Uses an Elixir-centric interface.
* Encode/decode CID, Human Readable CID
* Supports all Multibase, Multicodec
* Takes any Multihash, working long-term on upgrading Elixir Multihash implementations
* Supports CID v0 and CID v1, with checking for invalid versions/future versions
* Supports majority of what's in Python, JS, and Go implementations, leaving out anything that is implicit in Elixir such as comparing two structs for equality