### PR TITLE
make multibase in binary optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ A CIDv1 has four parts:
 # or, expanded:
 <cidv1> ::= <multibase-prefix><cid-version><multicodec-content-type><multihash-content-address>
 ```
+
 Where
 
-- `<multibase-prefix>` is a [multibase](https://github.com/multiformats/multibase) code (1 or 2 bytes), to ease encoding CIDs into various bases.
+- `<multibase-prefix>` is a [multibase](https://github.com/multiformats/multibase) code (1 or 2 bytes), to ease encoding CIDs into various bases. **NOTE:** *Binary* (not text-based) protocols and formats may omit the multibase prefix when the encoding is unambiguous.
 - `<cid-version>` is a [varint](https://github.com/multiformats/unsigned-varint) representing the version of CID, here for upgradability purposes.
 - `<multicodec-content-type>` is a [multicodec](https://github.com/multiformats/multicodec) code representing the content type or format of the data being addressed.
 - `<multihash-content-address>` is a [multihash](https://github.com/multiformats/multihash) value, representing the cryptographic hash of the content being addressed. Multihash enables CIDs to use many different cryptographic hash function, for upgradability and protocol agility purposes.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@
 ## Table of Contents
 
 - [Motivation](#motivation)
-- [How does it work? - Protocol Description](#how-does-it-work---protocol-description)
+- [What is it?](#what-is-it)
+- [How does it work?](#how-does-it-work)
 - [Design Considerations](#design-considerations)
 - [Human Readable CIDs](#human-readable-cids)
 - [Versions](#versions)
-  - [CIDv0](#cidv0)
-  - [CIDv1](#cidv1)
+    - [CIDv0](#cidv0)
+    - [CIDv1](#cidv1)
+- [Decoding Algorithm](#decoding-algorithm)
 - [Implementations](#implementations)
 - [FAQ](#faq)
 - [Maintainers](#maintainers)
@@ -27,9 +29,13 @@
 
 **You can read an in-depth discussion on why this format was needed in IPFS here: https://github.com/ipfs/specs/issues/130 (first post reproduced [here](./original-rfc.md))**
 
-## How does it work? - Protocol Description
+## What is it?
 
-CID is a self-describing content-addressed identifier. It uses cryptographic hashes to achieve content addressing. It uses several [multiformats](https://github.com/multiformats/multiformats) to achieve flexible self-description, namely [multihash](https://github.com/multiformats/multihash) for hashes, [multicodec](https://github.com/multiformats/multicodec) for data content types, and [multibase](https://github.com/multiformats/multibase) to encode the CID itself into strings.
+A CID is a self-describing content-addressed identifier. It uses cryptographic hashes to achieve content addressing. It uses several [multiformats](https://github.com/multiformats/multiformats) to achieve flexible self-description, namely [multihash](https://github.com/multiformats/multihash) for hashes, [multicodec](https://github.com/multiformats/multicodec) for data content types, and [multibase](https://github.com/multiformats/multibase) to encode the CID itself into strings.
+
+Concretely, it's *typed* content address: a tuple of `(content-type, content-address)`.
+
+## How does it work?
 
 Current version: CIDv1
 


### PR DESCRIPTION
It's still "conceptually" there. However, nobody wants to waste bytes by actually including the multibase in binary.